### PR TITLE
Allow typescript project as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
- ### Added
+### Added
 
-  - Allow define typescript project with `-p` parameter. This is useful to have a `tsconfig.json` in the root to allow IDE and library implementation to get a project file including files even if they won't be included in the NPM package (.spec, .test, .stories). Otherwise a project including this files will transform every file defined, even those not desired in the final bundle, not only forcing to exclude them explicitly but increasing compilation times and errors. DefaiBu default `tsconfig.json` will be used as it usually does.
+- Allow define typescript project with `-p` parameter. This is useful to have a `tsconfig.json` in the root to allow IDE and library implementation to get a project file including files even if they won't be included in the NPM package (.spec, .test, .stories). Otherwise a project including this files will transform every file defined, even those not desired in the final bundle, not only forcing to exclude them explicitly but increasing compilation times and errors. DefaiBu default `tsconfig.json` will be used as it usually does.
 
 ## [0.0.2] - 2021-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2022-10-27
+
 ### Added
 
 - Allow defining typescript project with `-p` parameter to define a different `tsconfig.ts` file. p.eg: `package-build -p tsconfig.build.json`. This is useful to have a `tsconfig.json` in the root to allow IDE and library implementation to get a project file including files even if they won't be included in the NPM package (.spec, .test, .stories). Otherwise, a project including these files will transform every file defined, even those not desired in the final bundle, not only forcing to exclude them explicitly but increasing compilation times and errors. By default `tsconfig.json` will be used as it usually does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ ### Added
+
+  - Allow define typescript project with `-p` parameter. This is useful to have a `tsconfig.json` in the root to allow IDE and library implementation to get a project file including files even if they won't be included in the NPM package (.spec, .test, .stories). Otherwise a project including this files will transform every file defined, even those not desired in the final bundle, not only forcing to exclude them explicitly but increasing compilation times and errors. DefaiBu default `tsconfig.json` will be used as it usually does.
+
 ## [0.0.2] - 2021-11-02
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ NOTICE: this package doesn't clean your build directories in each run, so you'd 
 
 #### Parameters
 
- - `-w` to watch the files.
- - `-p` to define a different `tsconfig.ts` file. p.eg: `package-build -p tsconfig.build.json`.
+- `-w` to watch the files.
+- `-p` to define a different `tsconfig.ts` file. p.eg: `package-build -p tsconfig.build.json`.
 
 ### Publish a new version
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Install this package as a dev dependency in your package, then create scripts in
 
 NOTICE: this package doesn't clean your build directories in each run, so you'd probably want to append something like `rimraf` to your dependencies.
 
+#### Parameters
+
+ - `-w` to watch the files.
+ - `-p` to define a different `tsconfig.ts` file. p.eg: `package-build -p tsconfig.build.json`.
+
 ### Publish a new version
 
 - Update [CHANGELOG](./CHANGELOG.md) with new features, breaking changes, etc

--- a/build.js
+++ b/build.js
@@ -33,10 +33,10 @@ const watch = (config) => {
   watcher.on('event', (event) => eventHandler(event));
 };
 
-const build = async (withWatch = false) => {
+const build = async (withWatch = false, project) => {
   const dirname = process.cwd();
   console.log(`Bundling ${dirname}`);
-  const { input, output } = getRollupConfig(dirname);
+  const { input, output } = getRollupConfig(dirname, project);
 
   if (withWatch) {
     watch({ ...input, output });
@@ -60,4 +60,4 @@ const build = async (withWatch = false) => {
 
 const argv = minimist(process.argv.slice(2));
 
-build(argv.w);
+build(argv.w, argv.p);

--- a/getRollupConfig.js
+++ b/getRollupConfig.js
@@ -15,7 +15,7 @@ const compileTypings = (cwd) => () => {
   });
 };
 
-module.exports = (dirname) => {
+module.exports = (dirname, project) => {
   const pkgPath = path.join(dirname, 'package.json');
   // eslint-disable-next-line import/no-dynamic-require, global-require
   const pkg = require(pkgPath);
@@ -40,7 +40,10 @@ module.exports = (dirname) => {
         return external.includes(namespace);
       },
       plugins: [
-        command(compileTypings(dirname), { exitOnFail: true, wait: true }),
+        command(compileTypings(project || dirname), {
+          exitOnFail: true,
+          wait: true,
+        }),
         resolve({ extensions }),
         commonjs(),
         babel({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cabify/package-build",
-  "version": "0.0.3-beta.0",
+  "version": "0.0.3-beta.1",
   "description": "Common configuration & scripts for building TS packages with rollup",
   "license": "Apache-2.0",
   "main": "build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cabify/package-build",
-  "version": "0.0.3-beta.2",
+  "version": "0.1.0",
   "description": "Common configuration & scripts for building TS packages with rollup",
   "license": "Apache-2.0",
   "main": "build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cabify/package-build",
-  "version": "0.0.3-beta.1",
+  "version": "0.0.3-beta.2",
   "description": "Common configuration & scripts for building TS packages with rollup",
   "license": "Apache-2.0",
   "main": "build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cabify/package-build",
-  "version": "0.0.2",
+  "version": "0.0.3-beta.0",
   "description": "Common configuration & scripts for building TS packages with rollup",
   "license": "Apache-2.0",
   "main": "build.js",
@@ -17,7 +17,6 @@
     "format:check": "prettier --check .",
     "typecheck": "echo 'No typecheck to perform'",
     "test:ci": "echo 'No test to perform'",
-
     "publish:major": "npm version major",
     "publish:minor": "npm version minor",
     "publish:patch": "npm version patch",


### PR DESCRIPTION
# Problem

While developing any project you expect the tools to work by default when type checking and linting, this includes this tool implementation in the IDE. Those tools use `tsconfig.json` by default which is something expected.

This configuration looks like this:

```json
# tsconfig.json
{
  ...some typescript configuration
  "include": ["src/**/*", ".jest/**/*", ".storybook/**/*"],
}
```

This configuration will cause `package-build` library to compile all files included in the Typescript configuration. This means it will include in the bundle useless files for distribution like unit tests, storybook stories and test helpers.

To avoid this we should be able to define a different file for configuration like `tsconfig.build.json` only including library entrypoint, usually `src/index.ts`.

```json
# tsconfig.build.json
{
  ...some typescript configuration
  "include": ["src/index.ts"],
}
```

This configuration will avoid transforming useless files into the bundle but allow the tools to use the root `tsconfig.json` as a reference.