### PR TITLE
Fix CJS-ESM module interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CJS-ESM interoperability.
+
 ## [0.1.1] - 2022-10-27
 
 ### Fixed

--- a/getRollupConfig.js
+++ b/getRollupConfig.js
@@ -65,6 +65,8 @@ module.exports = (dirname, project) => {
         file: pkg.main,
         format: 'cjs',
         sourcemap: true,
+        // See: https://rollupjs.org/configuration-options/#output-interop
+        interop: 'auto',
       },
       {
         file: pkg.module,


### PR DESCRIPTION
Since `@cabify/pakage-build@0.1.0` Rollup stopped adding a compatibility layer to some CJS modules and some packages built with this solution had problems when requiring default exports from other legacy packages. This MR tells Rollup to add the compatibility layer when it's needed.