### PR TITLE
Set package version from release tag before publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,4 +18,5 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: yarn install
       - run: yarn build
+      - run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
       - run: npm publish --provenance --tag ${{ contains(github.ref_name,'beta') && 'beta' || 'latest' }}

--- a/README.md
+++ b/README.md
@@ -28,12 +28,9 @@ NOTICE: this package doesn't clean your build directories in each run, so you'd 
 
 - Update [CHANGELOG](./CHANGELOG.md) with new features, breaking changes, etc
 - Check you're in `main` branch and everything is up-to-date.
-- Run `yarn publish:<major|minor|patch>` or `yarn publish:canary` for canary versions.
-- Run `git push && git push --tags`
-- Check all test actions triggered after previous push are ✔️.
-- Go to [create a new release](https://github.com/cabify/package-build-javascript/releases/new), select previously pushed tag and write a Title.
-- Check the action for publish the npm has finished with success.
-- [Check on npm package webpage](https://www.npmjs.com/package/@cabify/package-build), the version has been published successfully under `latest` tag.
+- Go to [create a new release](https://github.com/cabify/package-build-javascript/releases/new), create a new tag (e.g. `v0.2.0` or `v0.2.0-beta.0` for pre-releases) and write a Title.
+- The publish workflow will automatically set the package version from the tag and publish to npm with provenance.
+- [Check on npm package webpage](https://www.npmjs.com/package/@cabify/package-build) that the version has been published successfully.
 
 ## Contributors ✨
 


### PR DESCRIPTION
Adds `npm version` step to set the version from the git tag before `npm publish`, so we don't need to manually bump package.json.

Made with [Cursor](https://cursor.com)